### PR TITLE
Changes and fixes

### DIFF
--- a/src/components/_members.scss
+++ b/src/components/_members.scss
@@ -4,7 +4,7 @@
 
 .membersWrap-3NUR2t {
     background-color: transparent;
-    .members-3WRCEx {
+    .members-3WRCEx, &.members-3WRCEx > div {
         background-color: transparent;
         .member-2gU6Ar, .content-2a4AW9 {
             background-color: transparent;

--- a/src/components/_modal.scss
+++ b/src/components/_modal.scss
@@ -1,6 +1,7 @@
 @use 'modals/events';
 @use 'modals/keybinds';
 @use 'modals/account-switcher';
+@use 'modals/drawer-wrapper';
 @use 'modals/message-delete';
 @use 'modals/quick-switcher';
 @use 'modals/reactions';

--- a/src/components/_plugin.scss
+++ b/src/components/_plugin.scss
@@ -1,1 +1,2 @@
+@use 'plugins/better-discord';
 @use 'plugins/total-members';

--- a/src/components/_popout.scss
+++ b/src/components/_popout.scss
@@ -1,11 +1,13 @@
 @use 'popouts/add-game';
 @use 'popouts/autocomplete';
 @use 'popouts/color-picker';
+@use 'popouts/content-warning';
 @use 'popouts/context-menu';
 @use 'popouts/drawer-wrapper';
 @use 'popouts/inbox';
 @use 'popouts/member-roles';
 @use 'popouts/noise-suppression';
+@use 'popouts/overflow-roles';
 @use 'popouts/permissions-autocomplete';
 @use 'popouts/pinned';
 @use 'popouts/search';

--- a/src/components/modals/_drawer-wrapper.scss
+++ b/src/components/modals/_drawer-wrapper.scss
@@ -1,0 +1,46 @@
+#app-mount .root-g14mjS {
+    .contentWrapper-2pLX__, .emojiPicker-6YCk8a {
+        box-shadow: none;
+        background-color: var(--modal-background);
+    }
+    .inspector-DFKXwB {
+        padding-right: 0;
+        margin-left: -15px;
+        border-top: 1px solid var(--background-modifier-accent-alt);
+        background-color: var(--modal-background);
+    }
+    .wrapper-1NNaWG, .wrapper-22rqw6 {
+        background-color: var(--modal-background);
+    }
+    .header-11eigE {
+        box-shadow: none;
+        padding-right: 6px;
+        padding-bottom: 10px;
+        padding-left: 0;
+        margin: 0 15px;
+        border-bottom: 1px solid var(--background-modifier-accent-alt);
+    }
+    .container-1SX9VC .scrollerBase-_bVAAt {
+        background-color: var(--input-background);
+    }
+    .navList-OZXhFv {
+        .navItem-1Ka4aR {
+            color: var(--interactive-normal);
+            .navButtonActive-2Ad1wV {
+                color: var(--interactive-active);
+                background-color: var(--background-modifier-selected);
+            }
+            .navButton-2UXXaK {
+                &:hover {
+                    background-color: var(--background-modifier-hover);
+                }
+                &:active {
+                    background-color: var(--background-modifier-active);
+                }
+            }
+        }
+    }
+    .diversitySelectorOptionsInExpressionPicker-3wybQR {
+        right: 1px;
+    }
+}

--- a/src/components/modals/_keybinds.scss
+++ b/src/components/modals/_keybinds.scss
@@ -10,5 +10,9 @@
     .keybindShortcut-3zF1P9 .key-N5VmHN {
         box-shadow: inset 0 -4px 0 var(--background-secondary);
         background-color: var(--background-secondary-alt);
+        color: var(--interactive-normal);
+        g {
+            fill: var(--interactive-normal);
+        }
     }
 }

--- a/src/components/plugins/_better-discord.scss
+++ b/src/components/plugins/_better-discord.scss
@@ -1,0 +1,19 @@
+.updateNotice-2DjjHs {
+    margin: 0 var(--essence-app-padding) var(--essence-default-padding) !important;
+    border-radius: var(--essence-default-rounding) !important;
+}
+.bd-settings-title {
+    color: var(--header-primary);
+}
+.bd-toast {
+    background-color: var(--background-floating);
+    &.toast-success {
+        background-color: hsl(var(--essence-accent-green));
+    }
+    &.toast-warning {
+        background-color: hsl(var(--essence-accent-yellow));
+    }
+    &.toast-danger, &.toast-error {
+        background-color: hsl(var(--essence-accent-red));
+    }
+}

--- a/src/components/popouts/_content-warning.scss
+++ b/src/components/popouts/_content-warning.scss
@@ -1,0 +1,14 @@
+#app-mount .layer-2aCOJ3 {
+    .contentWarningPopout-WKdbDG {
+        border-radius: var(--essence-default-rounding);
+        box-shadow: var(--elevation-stroke), var(--elevation-high);
+        -webkit-box-shadow: var(--elevation-stroke), var(--elevation-high);
+        background-color: var(--background-floating);
+        .footer-2aeMle {
+            margin: 0 15px;
+            padding: 16px 0;
+            border-top: 1px solid var(--background-modifier-accent);
+            background-color: var(--background-floating);
+        }
+    }
+}

--- a/src/components/popouts/_drawer-wrapper.scss
+++ b/src/components/popouts/_drawer-wrapper.scss
@@ -54,6 +54,9 @@
             }
         }
     }
+    .diversitySelectorOptionsInExpressionPicker-3wybQR {
+        right: 1px;
+    }
     // || Loading Content
     .imageLoading-2uloYN {
         border-radius: 30%;
@@ -68,5 +71,8 @@
         &:hover::after {
             box-shadow: inset 0 0 0 2px hsl(var(--essence-accent-brand)),inset 0 0 0 3px var(--background-floating);
         }
+    }
+    .emptyHintCard-2A7Tng {
+        background-color: var(--background-primary);
     }
 }

--- a/src/components/popouts/_overflow-roles.scss
+++ b/src/components/popouts/_overflow-roles.scss
@@ -1,0 +1,8 @@
+#app-mount .layer-2aCOJ3 {
+    .overflowRolesPopout-1Puiuq, .overflowRolesPopoutArrow-2R7g3K {
+        border-radius: var(--essence-default-rounding);
+        box-shadow: var(--elevation-stroke), var(--elevation-high);
+        -webkit-box-shadow: var(--elevation-stroke), var(--elevation-high);
+        background-color: var(--background-floating);
+    }
+}

--- a/src/components/popouts/_search.scss
+++ b/src/components/popouts/_search.scss
@@ -20,7 +20,7 @@
         }
     }
 
-    // || Search Popount Container
+    // || Search Popout Container
     .searchAnswer-23w-CH,
     .searchFilter-2UfsDk {
         color: var(--text-normal);

--- a/src/layout/_app.scss
+++ b/src/layout/_app.scss
@@ -23,6 +23,9 @@
         }
     }
 }
+.errorPage-2pZ2Kq .buttons-228G5H {
+    -webkit-app-region: no-drag;
+}
 .platform-win .layers-OrUESM {
     margin-top: 0;
 }

--- a/src/layout/_notice.scss
+++ b/src/layout/_notice.scss
@@ -5,6 +5,15 @@
     &.notice-1x8lm- {
         background-color: hsl(var(--essence-accent-brand));
     }
+    &.colorDefault-1e8tQv {
+        background-color: hsl(var(--essence-accent-green));
+    }
+    &.colorWarning-3oV0Ge {
+        background-color: hsl(var(--essence-accent-yellow));
+    }
+    &.colorDanger-2YLzLC {
+        background-color: hsl(var(--essence-accent-red));
+    }
     &.colorStreamerMode-8uoRWd {
         background-color: hsl(var(--essence-accent-purple));
     }

--- a/src/pages/_chat.scss
+++ b/src/pages/_chat.scss
@@ -154,4 +154,7 @@
         border-radius: var(--essence-default-rounding);
         background-color: var(--background-primary);
     }
+    .subscriptionPerks-17BiNa {
+        background-color: var(--background-tertiary);
+    }
 }

--- a/src/pages/_forums.scss
+++ b/src/pages/_forums.scss
@@ -2,13 +2,14 @@
     .container-3wLKDe {
         border-radius: var(--essence-default-rounding);
         background-color: var(--background-primary);
-        .mainCard-3KBsBI, .sidebarCard-1Gn1ch, .container-2IhveL {
+        .mainCard-3KBsBI, .sidebarCard-1Gn1ch,
+        .container-2IhveL, .container-2nXUah, .container-2_J666 {
             border-color: var(--background-tertiary);
             background-color: var(--background-tertiary);
         }
         .pill-3pRQlO {
             background-color: var(--background-modifier-accent);
-            &:hover {
+            &.clickable-3YTfAq:not(.disabled-3Rezaw):hover {
                 background-color: var(--background-modifier-hover);
             }
         }
@@ -41,19 +42,25 @@
                 &::before {
                     content: none;
                 }
-                .container-3YcgdM {
-                    border-top: none;
-                }
-                .divider-AZrXIA {
-                    margin-left: 15px;
-                    height: 1px;
-                    width: calc(100% - 30px);
-                }
             }
         }
         ~ .resizeHandle-PBRzPC {
             margin-left: -10px;
             margin-right: 10px;
         }
+    }
+    .botTagOP-3pUTXu {
+        color: #fff;
+    }
+    .header-1RJoTb {
+        border-top-left-radius: 8px;
+    }
+    .container-3YcgdM {
+        border-top: none;
+    }
+    .divider-AZrXIA {
+        margin-left: 15px;
+        height: 1px;
+        width: calc(100% - 30px);
     }
 }

--- a/src/pages/_membership.scss
+++ b/src/pages/_membership.scss
@@ -1,0 +1,11 @@
+.container-2_BXG- {
+    margin: var(--essence-default-padding);
+    .scroller-38C5lh {
+        border-radius: var(--essence-default-rounding);
+    }
+    .coverImage-2FIeGi {
+        border-radius: var(--essence-default-rounding);
+        margin: 8px;
+        max-width: -webkit-fill-available;
+    }
+}

--- a/src/pages/settings/_server.scss
+++ b/src/pages/settings/_server.scss
@@ -134,6 +134,14 @@
     .getStartedWrapper-2mNX-j {
         background-color: var(--background-tertiary);
     }
+    .exampleContainer-2O-nVK {
+        .exampleModal-1lRfuE, .content-pHpkq8, .footer-11k_3m {
+            background-color: var(--modal-background);
+        }
+        .guildSidebar-pjuGkm {
+            background-color: var(--background-tertiary);
+        }
+    }
 
     // || Welcome Screen
     .previewContainer-29oeA6 {

--- a/src/pages/settings/_user.scss
+++ b/src/pages/settings/_user.scss
@@ -281,13 +281,13 @@
     // || Game Overlay
     .wrapper-SdcMKg {
         border-color: hsl(var(--essence-accent-brand));
-        .option-1QI4c9 {
+        .option-1QI4c9:not(:hover) {
             background-color: var(--background-secondary-alt);
             &.selected-18Wszc {
                 background-color: hsl(var(--essence-accent-brand));
             }
         }
-        .disabled-35mc5w {
+        .disabled-35mc5w:not(:hover) {
             color: var(--background-secondary-alt);
             &.selected-18Wszc {
                 color: hsl(var(--essence-accent-red));

--- a/src/source.scss
+++ b/src/source.scss
@@ -27,5 +27,6 @@
 @use 'pages/forums';
 @use 'pages/guild-home';
 @use 'pages/login';
+@use 'pages/membership';
 @use 'pages/user-home';
 @use 'pages/voice';


### PR DESCRIPTION
I've found more things not themed or weird looking, so here is a fix. I have many other things that I have noticed to be weird or broken, probably creating an issue with everything listed later on.
I'm not putting screenshots of everything, unless asked.

**Changes made:**
- Themed:
  - Members list in threads/forums.
  - Drawer wrapper as a modal; found when setting role icons or tier icons.
  - Content warning popout; found when trying to send an @everyone in a large server or a possible auth token.
  - GIFs favorites placeholder.
  - Overflow roles popout; found in the member list if the roles do not fit on the screen.
  - Replaced all notices colors with essence's accent colors.
  - More forum channels cards; get started tutorial and no posts available.
  - Premium Membership channels; made the channel fit with the correct margins like in other channels, server banner is rounded like all banners on the app and the tier perks list is the same as the tier header.
  - Rules Screening example; made it how it would actually look like on the real modal.
- Themed some Better Discord specific areas:
  - Made the update plugin notice fit with the rest of the app.
  - Fixed header in settings when in light mode.
  - Replaced toasts colors with essence's accent colors.
- Fixed the emoji diversity selector being a little off.
- Fixed the keybind text when in light mode; used to be always white.
- Fixed the drag region if the app crashes; now it's possible to reload.
- Fixed forum tags hover; shouldn't be possible to hover on them if they are not clickable or disabled.
- Fixed forum full view header; styles were only applied on split view, even if the header was in full view too.
- Fixed forum OP tag text being the same color as the tag.
- Fixed the game overlay position setting hover.