### PR TITLE
Updated guild home

### DIFF
--- a/src/components/_modal.scss
+++ b/src/components/_modal.scss
@@ -2,6 +2,7 @@
 @use 'modals/add-to-dm';
 @use 'modals/events';
 @use 'modals/feature-message';
+@use 'modals/guild-home-curate';
 @use 'modals/keybinds';
 @use 'modals/drawer-wrapper';
 @use 'modals/message-delete';

--- a/src/components/_modal.scss
+++ b/src/components/_modal.scss
@@ -1,6 +1,7 @@
 @use 'modals/account-switcher';
 @use 'modals/add-to-dm';
 @use 'modals/events';
+@use 'modals/feature-message';
 @use 'modals/keybinds';
 @use 'modals/drawer-wrapper';
 @use 'modals/message-delete';

--- a/src/components/modals/_feature-message.scss
+++ b/src/components/modals/_feature-message.scss
@@ -1,0 +1,7 @@
+#app-mount .root-g14mjS {
+    .featureModalMessage-fZR6jp {
+        box-shadow: var(--elevation-stroke), var(--elevation-high);
+        -webkit-box-shadow: var(--elevation-stroke), var(--elevation-high);
+        background-color: var(--background-primary);
+    }
+}

--- a/src/components/modals/_guild-home-curate.scss
+++ b/src/components/modals/_guild-home-curate.scss
@@ -1,0 +1,5 @@
+#app-mount .root-g14mjS {
+    .dummySwitch-fxMi2_ {
+        background-color: hsl(var(--essence-accent-green));
+    }
+}

--- a/src/pages/_guild-home.scss
+++ b/src/pages/_guild-home.scss
@@ -2,15 +2,17 @@
     .title-31SJ6t.background-fkKrXt {
         background-color: var(--background-primary);
     }
-    .card-3x20HF {
-        background-color: var(--background-tertiary);
-    }
+    .card-3x20HF,
     .container-2Hi7Km,
+    .container-3rZ3XA,
     .container-xwOzwi,
-    .emptyStateContainer-xWOMPJ {
+    .card-3x20HF .wrapper-15CKyy {
         background-color: var(--background-tertiary);
     }
-    @media(max-width: 1300px) {
+    .emptyStateContainer-xWOMPJ {
+        background-color: var(--background-secondary);
+    }
+    @media (max-width: 1300px) {
         .container-xwOzwi,
         .container-3rZ3XA {
             background-color: var(--background-primary);
@@ -19,5 +21,19 @@
         .emptyStateContainer-xWOMPJ {
             background-color: var(--background-tertiary);
         }
+    }
+    .icon-2IDTxf {
+        border-color: var(--background-tertiary);
+    }
+    .iconContainer-2R-3M1,
+    .moreUsers-_v6T-L,
+    .typingIndicator-KF8hGa {
+        background-color: var(--background-primary);
+    }
+    .previewContainer-3BJM_S {
+        background-color: var(--background-secondary);
+    }
+    .dummySwitch-fxMi2_ {
+        background-color: hsl(var(--essence-accent-green));
     }
 }

--- a/src/pages/_guild-home.scss
+++ b/src/pages/_guild-home.scss
@@ -22,6 +22,9 @@
             background-color: var(--background-tertiary);
         }
     }
+    .dotOnline-3uN0x9 {
+        background-color: hsl(var(--essence-accent-green));
+    }
     .icon-2IDTxf {
         border-color: var(--background-tertiary);
     }

--- a/src/pages/_guild-home.scss
+++ b/src/pages/_guild-home.scss
@@ -33,7 +33,4 @@
     .previewContainer-3BJM_S {
         background-color: var(--background-secondary);
     }
-    .dummySwitch-fxMi2_ {
-        background-color: hsl(var(--essence-accent-green));
-    }
 }


### PR DESCRIPTION
This PR fixes some missed stuff regarding the guild home.

**Changes made:**
- Feature a message in home feed #20 .
- Themed and fixed events card, placeholder cards when loading, empty card, icon borders, chat and channel indicators, stream preview, use the correct green on a fake slider on home curate showcase for moderators and for the online dot.

![image](https://user-images.githubusercontent.com/38290480/182654754-dca22d8b-b4d6-441a-9385-72bb8f13d823.png)
![image](https://user-images.githubusercontent.com/38290480/182654766-9a8d61c0-da14-4365-8838-b837ec8f199f.png)
![image](https://user-images.githubusercontent.com/38290480/182664256-e0192b89-38f4-4fe2-aacf-2d2cd684e58a.png)
![image](https://user-images.githubusercontent.com/38290480/182655609-7813954b-7dac-4897-ac55-7a6ec56d8c25.png)